### PR TITLE
set up for maven publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bin/
 # fabric
 
 run/
+private.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,15 @@
 plugins {
 	id 'fabric-loom' version '0.2.3-SNAPSHOT'
 	id 'maven-publish'
+	id "com.jfrog.artifactory" version "4.9.0"
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+
+if(rootProject.file('private.gradle').exists()) { //Publishing details
+	apply from: 'private.gradle'
+}
 
 archivesBaseName = project.archives_base_name
 version          = project.mod_version
@@ -49,19 +54,59 @@ jar {
 	from "UNLICENSE"
 }
 
+// configure the maven publication
 publishing {
 	publications {
-		mavenJava(MavenPublication) {
-			artifact(jar) {
+		maven(MavenPublication) {
+			// add all the jars that should be included when publishing to maven
+			//artifact(jar) {
+			//	builtBy remapJar
+			//}
+			artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}.jar") { //release jar - file location not provided anywhere in loom
+				classifier null
 				builtBy remapJar
 			}
+
+			artifact ("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}-dev.jar") { //release jar - file location not provided anywhere in loom
+				classifier "dev"
+				builtBy remapJar
+			}
+
 			artifact(sourcesJar) {
 				builtBy remapSourcesJar
 			}
 		}
 	}
-	
+
+	// select the repositories you want to publish to
 	repositories {
+		// uncomment to publish to the local maven
 		// mavenLocal()
+	}
+}
+
+artifactory {
+	if (project.hasProperty("artifactoryUsername")) {
+		contextUrl = "http://server.bbkr.space:8081/artifactory/"
+		publish {
+			repository {
+				if (version.contains("SNAPSHOT")) {
+					repoKey = "libs-snapshot"
+				} else {
+					repoKey = "libs-release"
+				}
+
+				username = artifactoryUsername
+				password = artifactoryPassword
+			}
+			defaults {
+				publications("maven")
+
+				publishArtifacts = true
+				publishPom = true
+			}
+		}
+	} else {
+		println "Cannot configure artifactory; please define ext.artifactoryUsername and ext.artifactoryPassword before running artifactoryPublish"
 	}
 }


### PR DESCRIPTION
Updates build.gradle to be able to publish to Maven. To use, create a `private.gradle` file in the root with the following setup:
```groovy
ext {
    artifactoryUsername = <username>
    artifactoryPassword = <password>
}
```
Then, run `./gradlew artifactoryPublish` to build a new version and publish it to maven.